### PR TITLE
Change entry points

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,5 +30,5 @@ Export the style as CSS
 -----------------------
 ::
 
-   pygmentize -S solarizedlight -f html > solarizedlight.css
+   pygmentize -S solarized-light -f html > solarizedlight.css
 

--- a/setup.py
+++ b/setup.py
@@ -37,8 +37,8 @@ setup(
     install_requires=['pygments >= 1.5'],
     entry_points="""
         [pygments.styles]
-        solarizedlight=pygments_style_solarized.light:LightStyle
-        solarizeddark=pygments_style_solarized.dark:DarkStyle
+        solarized-light=pygments_style_solarized.light:LightStyle
+        solarized-dark=pygments_style_solarized.dark:DarkStyle
     """,
     zip_safe=False,
 )


### PR DESCRIPTION
Pygments syntax highlighter uses the hyphen to separate the color variation from the name (ex. [paraiso-dark](https://bitbucket.org/birkenfeld/pygments-main/src/7941677dc77d4f2bf0bbd6140ade85a9454b8b80/pygments/styles/__init__.py?at=default&fileviewer=file-view-default#__init__.py-40))